### PR TITLE
Introduces SpanIdGenerator, used to control id generation.

### DIFF
--- a/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/Brave.java
@@ -3,9 +3,9 @@ package com.github.kristofa.brave;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import static com.github.kristofa.brave.InetAddressUtilities.*;
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * Builds brave api objects.
@@ -36,7 +36,7 @@ public class Brave {
         private List<TraceFilter> traceFilters = new ArrayList<>();
         private SpanCollector spanCollector = new LoggingSpanCollector();
         private ServerAndClientSpanState state;
-        private Random random = new Random();
+        private SpanIdGenerator spanIdGenerator = new SpanIdGenerator.Default();
 
         /**
          * Builder which initializes with serviceName = "unknown".
@@ -108,6 +108,12 @@ public class Brave {
          */
         public Builder spanCollector(SpanCollector spanCollector) {
             this.spanCollector = spanCollector;
+            return this;
+        }
+
+        /** Used to generate new trace/span ids. */
+        public Builder idGenerator(SpanIdGenerator spanIdGenerator) {
+            this.spanIdGenerator = checkNotNull(spanIdGenerator, "Null spanIdGenerator");
             return this;
         }
 
@@ -190,13 +196,13 @@ public class Brave {
 
     private Brave(Builder builder) {
         serverTracer = ServerTracer.builder()
-                .randomGenerator(builder.random)
+                .idGenerator(builder.spanIdGenerator)
                 .spanCollector(builder.spanCollector)
                 .state(builder.state)
                 .traceFilters(builder.traceFilters).build();
 
         clientTracer = ClientTracer.builder()
-                .randomGenerator(builder.random)
+                .idGenerator(builder.spanIdGenerator)
                 .spanCollector(builder.spanCollector)
                 .state(builder.state)
                 .traceFilters(builder.traceFilters).build();

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanIdGenerator.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanIdGenerator.java
@@ -1,0 +1,30 @@
+package com.github.kristofa.brave;
+
+import com.github.kristofa.brave.internal.Nullable;
+
+import java.util.Random;
+
+/**
+ * Allows you to control how ids are generated. For example, implementations
+ * can encode where in the call tree the span originates from, or use alternate
+ * random number generators.
+ */
+// Intentionally single-method to be implementable with a lambda
+public interface SpanIdGenerator {
+
+    /** Returns the next trace id, or span id if parent is null. */
+    SpanId nextSpanId(@Nullable SpanId parent);
+
+    final class Default implements SpanIdGenerator {
+        private final Random random = new Random();
+
+        @Override
+        public SpanId nextSpanId(@Nullable SpanId parent) {
+            long nextLong = random.nextLong();
+            if (parent == null) {
+                return SpanId.create(nextLong, nextLong, null);
+            }
+            return SpanId.create(parent.getTraceId(), nextLong, parent.getSpanId());
+        }
+    }
+}


### PR DESCRIPTION
There are a few use cases that support decoupling ID generation

* allow an alternate random generator, or change its seed to avoid collisions
* opt out of span id == trace id for the root span
* make trace-id a request-id, for log correlation, regardless of sampling
* make Brave easier to test